### PR TITLE
Active Timetable Links

### DIFF
--- a/app/Actions/Course/CourseTimetableLink.php
+++ b/app/Actions/Course/CourseTimetableLink.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Actions\Course;
+
+use App\Models\Course;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class CourseTimetableLink
+{
+    use AsAction;
+
+    public function handle(Course $course, $week = null)
+    {
+        // The base of a timetable link is made up of the course identifier.
+        $url = sprintf(config('services.lit.relay.timetable.route'), $course->identifier);
+
+        // for debug/demo mode we might want to override the week.
+        if (config('services.lit.relay.timetable.week')) {
+            $week .= config('services.lit.relay.timetable.week');
+        }
+
+        // we can specify a week we want to return form the url.
+        if ($week) {
+            $url .= sprintf("&weeks=%s", $week);
+        }
+
+        return $url;
+    }
+}

--- a/app/Actions/Course/CourseTimetableLink.php
+++ b/app/Actions/Course/CourseTimetableLink.php
@@ -9,7 +9,7 @@ class CourseTimetableLink
 {
     use AsAction;
 
-    public function handle(Course $course, $week = null)
+    public function handle(Course $course, int $week = null)
     {
         // The base of a timetable link is made up of the course identifier.
         $url = sprintf(config('services.lit.relay.timetable.route'), $course->identifier);

--- a/app/Actions/Course/FetchTimetable.php
+++ b/app/Actions/Course/FetchTimetable.php
@@ -16,10 +16,10 @@ class FetchTimetable extends HttpBrowser
     public function handle(Course $course): Collection
     {
         $start    = microtime(1);
-        $response = parent::request('GET', $course->source());
+        $response = parent::request('GET', $course->timetableLink());
 
         if ($this->getInternalResponse()->getStatusCode() !== 200) {
-            throw new CourseUrlReceivedBadStatusCode('Response '. $this->getInternalResponse()->getStatusCode().' from '.$course->source());
+            throw new CourseUrlReceivedBadStatusCode('Response '. $this->getInternalResponse()->getStatusCode().' from '.$course->timetableLink());
         }
 
         $parser = (new ParseTimetableService($response))->allSchedules();
@@ -28,7 +28,7 @@ class FetchTimetable extends HttpBrowser
         $course->requests()->create([
             'response' => $this->getInternalResponse()->getStatusCode(),
             'time' => round(($finish - $start), 3),
-            'link' => $course->source(),
+            'link' => $course->timetableLink(),
             'meta' => $parser['meta'],
             'mined' => $parser->get('schedules'),
         ]);

--- a/app/Actions/Course/FetchTimetable.php
+++ b/app/Actions/Course/FetchTimetable.php
@@ -13,13 +13,13 @@ class FetchTimetable extends HttpBrowser
 {
     use AsAction;
 
-    public function handle(Course $course): Collection
+    public function handle(Course $course, string $timetable_link): Collection
     {
         $start    = microtime(1);
-        $response = parent::request('GET', $course->timetableLink());
+        $response = parent::request('GET', $timetable_link);
 
         if ($this->getInternalResponse()->getStatusCode() !== 200) {
-            throw new CourseUrlReceivedBadStatusCode('Response '. $this->getInternalResponse()->getStatusCode().' from '.$course->timetableLink());
+            throw new CourseUrlReceivedBadStatusCode('Response '. $this->getInternalResponse()->getStatusCode().' from '. $timetable_link);
         }
 
         $parser = (new ParseTimetableService($response))->allSchedules();
@@ -28,7 +28,7 @@ class FetchTimetable extends HttpBrowser
         $course->requests()->create([
             'response' => $this->getInternalResponse()->getStatusCode(),
             'time' => round(($finish - $start), 3),
-            'link' => $course->timetableLink(),
+            'link' => $timetable_link,
             'meta' => $parser['meta'],
             'mined' => $parser->get('schedules'),
         ]);

--- a/app/Actions/Course/SynchronizeSchedule.php
+++ b/app/Actions/Course/SynchronizeSchedule.php
@@ -9,6 +9,7 @@ use App\Models\Module;
 use App\Models\Room;
 use App\Models\Type;
 use App\Services\AsynchronousModelService;
+use App\Services\SemesterPeriodDateService;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -21,15 +22,21 @@ class SynchronizeSchedule
     /**
      * @throws Exception
      */
-    public function handle(Course $course)
+    public function handle(Course $course, int $week)
     {
         try {
+            /**
+             * Get the current week that the semester is running on so that we
+             * can get the timetable for this week, and the one after/before.
+             */
+            $timetable_link = CourseTimetableLink::run($course, $week);
+
             /**
              * A custom request class that will track outgoing requests
              * to the timetable on the third party service.
              * This fires a http request to the third party service.
              */
-            $timetable = FetchTimetable::run($course);
+            $timetable = FetchTimetable::run($course, $timetable_link);
 
             /**
              * Get the academic week of the incoming request timetable.

--- a/app/Console/Commands/RelaySyncCommand.php
+++ b/app/Console/Commands/RelaySyncCommand.php
@@ -10,6 +10,7 @@ use App\Models\Synchronization;
 use App\Exceptions\CourseMissingLocation;
 use App\Services\Parsers\ParseCourseNameService;
 use App\Services\Parsers\ParseFilterService;
+use App\Services\SemesterPeriodDateService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -108,13 +109,17 @@ class RelaySyncCommand extends Command
         /**
          * Get all the courses in the filter, map to an array
          * associate with a campus and save into database
-         * if it does not exist.
+         * if it does not exist. We use the semester period
+         * date service to get the current semester period.
          */
         $output = $this->output;
         $course = Course::all();
         $output->progressStart($course->count());
-        $course->each(function (Course $course) use ($output) {
-            SynchronizeSchedule::dispatch($course);
+
+        $period = app(SemesterPeriodDateService::class);
+
+        $course->each(function (Course $course) use ($output, $period) {
+            SynchronizeSchedule::dispatch($course, $period->week());
             $output->progressAdvance(1);
         });
 

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -103,11 +103,6 @@ class Course extends Model implements SearchableInterface
         return route('course', $this);
     }
 
-    public function timetableLink(): string
-    {
-        return (new CourseTimetableLink)->handle($this);
-    }
-
     public function getIconCategoryAttribute(): string
     {
         return $this->department->name;

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Actions\Course\CourseTimetableLink;
 use App\Interfaces\SearchableInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -102,15 +103,9 @@ class Course extends Model implements SearchableInterface
         return route('course', $this);
     }
 
-    public function source(): string
+    public function timetableLink(): string
     {
-        $source = sprintf(config('services.lit.relay.timetable.route'), $this->identifier);
-
-        if (config('services.lit.relay.timetable.week')) {
-            $source .= sprintf("&weeks=%s", config('services.lit.relay.timetable.week'));
-        }
-
-        return $source;
+        return (new CourseTimetableLink)->handle($this);
     }
 
     public function getIconCategoryAttribute(): string

--- a/resources/views/timetable.blade.php
+++ b/resources/views/timetable.blade.php
@@ -57,7 +57,7 @@
                         @livewire('buttons.timetable-subscribe-button', ['timetable' => $model])
 
                         @if ($model->identifier != null)
-                            <a target="_blank" href="{{ $model->source() }}" class="inline-flex items-center px-3 py-2 mt-2 text-sm font-medium leading-4 text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm md:mt-0 dark:button dark:border-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                            <a target="_blank" href="{{ $model->timetableLink() }}" class="inline-flex items-center px-3 py-2 mt-2 text-sm font-medium leading-4 text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm md:mt-0 dark:button dark:border-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                 {{ __('View Timetable @LIT') }}
                             </a>
                         @endif

--- a/resources/views/timetable.blade.php
+++ b/resources/views/timetable.blade.php
@@ -57,7 +57,7 @@
                         @livewire('buttons.timetable-subscribe-button', ['timetable' => $model])
 
                         @if ($model->identifier != null)
-                            <a target="_blank" href="{{ $model->timetableLink() }}" class="inline-flex items-center px-3 py-2 mt-2 text-sm font-medium leading-4 text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm md:mt-0 dark:button dark:border-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                            <a target="_blank" href="{{ App\Actions\Course\CourseTimetableLink::run($model, $semester->week()) }}" class="inline-flex items-center px-3 py-2 mt-2 text-sm font-medium leading-4 text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm md:mt-0 dark:button dark:border-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                 {{ __('View Timetable @LIT') }}
                             </a>
                         @endif

--- a/tests/Unit/Actions/Course/CourseTimetableLinkTest.php
+++ b/tests/Unit/Actions/Course/CourseTimetableLinkTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Course\CourseTimetableLink as CourseCourseTimetableLink;
+use App\Models\Course;
+use CourseTimetableLink;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class CourseTimetableLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_a_course_link()
+    {
+        $course = Course::factory()->create(['identifier' => 'CSC108H1']);
+
+        $timetableLink = new CourseCourseTimetableLink;
+
+        $expectedResult = sprintf(config('services.lit.relay.timetable.route'), 'CSC108H1');
+
+        $this->assertEquals($expectedResult, $timetableLink->handle($course));
+    }
+
+    public function test_it_returns_a_course_link_with_a_specified_week()
+    {
+        $course = Course::factory()->create(['identifier' => 'CSC108H1']);
+
+        $timetableLink = new CourseCourseTimetableLink;
+
+        $expectedResult = "http://timetable.lit.ie:8080/reporting/individual;student+set;id;CSC108H1?t=student+set+individual&template=student+set+individual&weeks=24";
+
+        $this->assertEquals($expectedResult, $timetableLink->handle($course, 24));
+    }
+}

--- a/tests/Unit/Models/CourseTest.php
+++ b/tests/Unit/Models/CourseTest.php
@@ -67,15 +67,6 @@ class CourseTest extends TestCase
         $this->assertEquals('m_sltSmgmt4B', $course->identifier);
     }
 
-    public function test_course_has_a_timetable_link()
-    {
-        $course = Course::factory()->create(['identifier' => 'm_sltSmgmt4B']);
-
-        $expected = sprintf(config('services.lit.relay.timetable.route'), 'm_sltSmgmt4B');
-
-        $this->assertEquals($expected, $course->timetableLink());
-    }
-
     public function test_course_has_a_year()
     {
         $course = Course::factory()->create(['year' => 4]);

--- a/tests/Unit/Models/CourseTest.php
+++ b/tests/Unit/Models/CourseTest.php
@@ -67,6 +67,15 @@ class CourseTest extends TestCase
         $this->assertEquals('m_sltSmgmt4B', $course->identifier);
     }
 
+    public function test_course_has_a_timetable_link()
+    {
+        $course = Course::factory()->create(['identifier' => 'm_sltSmgmt4B']);
+
+        $expected = sprintf(config('services.lit.relay.timetable.route'), 'm_sltSmgmt4B');
+
+        $this->assertEquals($expected, $course->timetableLink());
+    }
+
     public function test_course_has_a_year()
     {
         $course = Course::factory()->create(['year' => 4]);

--- a/tests/Unit/Timetable/SemesterTest.php
+++ b/tests/Unit/Timetable/SemesterTest.php
@@ -6,7 +6,7 @@ use App\Services\SemesterPeriodDateService;
 use Carbon\Carbon;
 use Tests\TestCase;
 
-class SemesterTest extends TestCase
+class SemesterPeriodDateServiceTest extends TestCase
 {
     public function test_it_can_get_first_semester_starting_date_in_current_year()
     {


### PR DESCRIPTION
This makes links send and use the current week, rather than fetching no week and assuming latest.
This therefore fixes the navigation of lit timetable if viewing from the site and allows the addition of future week navigation from the site,